### PR TITLE
[2.0.r1] Sync script with our most advanced version

### DIFF
--- a/cp_headers.sh
+++ b/cp_headers.sh
@@ -92,51 +92,41 @@ HEADER_OVERRIDES="\
 
 cd ../../../..
 
+> out/cp_headers_5.15.log
+
 source build/envsetup.sh
 lunch aosp_xqdq54-trunk_staging-userdebug
 
-for x in $LINUX_HEADERS; do \
-cp $HEADER_SRC/$x $HEADER_ORI/$x
-$CLEAN_HEADER -u -v -k $HEADER_ORI -d $HEADER_SAN $x &>out/cp_headers_5.15.log
-done
+process_headers() {
+    local headers=$1
+    local src=$2
+    local dest=$3
 
-for x in $UAPI_HEADERS; do \
-cp $HEADER_SRC/"uapi/"$x $HEADER_ORI/$x
-$CLEAN_HEADER -u -v -k $HEADER_ORI -d $HEADER_SAN $x &>>out/cp_headers_5.15.log
-done
+    for x in $headers; do
+        mkdir -p $(dirname "$HEADER_ORI/$dest$x")
+        cp "$HEADER_SRC/$src$x" "$HEADER_ORI/$dest$x"
+        $CLEAN_HEADER -u -v -k "$HEADER_ORI" -d "$HEADER_SAN" "$dest$x" &>> out/cp_headers_5.15.log
+    done
+}
 
-for x in $TECHPACK_AUDIO_UAPI_HEADERS; do \
-cp $HEADER_SRC/"../techpack/audio/include/uapi/audio/"$x $HEADER_ORI/$x
-$CLEAN_HEADER -u -v -k $HEADER_ORI -d $HEADER_SAN $x &>>out/cp_headers_5.15.log
-done
+process_headers "$LINUX_HEADERS" "" ""
 
-for x in $TECHPACK_CAMERA_UAPI_HEADERS; do \
-cp $HEADER_SRC/"../techpack/camera/include/uapi/camera/"$x $HEADER_ORI/$x
-$CLEAN_HEADER -u -v -k $HEADER_ORI -d $HEADER_SAN $x &>>out/cp_headers_5.15.log
-done
+process_headers "$UAPI_HEADERS" "uapi/" ""
 
-for x in $TECHPACK_DISPLAY_UAPI_HEADERS; do \
-cp $HEADER_SRC/"../techpack/display/include/uapi/"$x $HEADER_ORI/$x
-$CLEAN_HEADER -u -v -k $HEADER_ORI -d $HEADER_SAN $x &>>out/cp_headers_5.15.log
-done
+process_headers "$TECHPACK_AUDIO_UAPI_HEADERS" "../techpack/audio/include/uapi/audio/" ""
 
-for x in $TECHPACK_GRAPHICS_UAPI_HEADERS; do \
-cp $HEADER_SRC/"../techpack/graphics/include/uapi/"$x $HEADER_ORI/$x
-$CLEAN_HEADER -u -v -k $HEADER_ORI -d $HEADER_SAN $x &>>out/cp_headers_5.15.log
-done
+process_headers "$TECHPACK_CAMERA_UAPI_HEADERS" "../techpack/camera/include/uapi/camera/" ""
 
-for x in $TECHPACK_SECUREMSM_UAPI_HEADERS; do \
-cp $HEADER_SRC/"../techpack/securemsm/"$x $HEADER_ORI/$x
-$CLEAN_HEADER -u -v -k $HEADER_ORI -d $HEADER_SAN $x &>>out/cp_headers_5.15.log
-done
+process_headers "$TECHPACK_DISPLAY_UAPI_HEADERS" "../techpack/display/include/uapi/" ""
 
-for x in $TECHPACK_VIDEO_UAPI_HEADERS; do \
-cp $HEADER_SRC/"../techpack/video/driver/vidc/inc/"$x $HEADER_ORI/media/$x
-$CLEAN_HEADER -u -v -k $HEADER_ORI/media/ -d $HEADER_SAN/media/ $x &>>out/cp_headers_5.15.log
-done
+process_headers "$TECHPACK_GRAPHICS_UAPI_HEADERS" "../techpack/graphics/include/uapi/" ""
+
+process_headers "$TECHPACK_SECUREMSM_UAPI_HEADERS" "../techpack/securemsm/" ""
+
+process_headers "$TECHPACK_VIDEO_UAPI_HEADERS" "../techpack/video/driver/vidc/inc/" "media/"
 
 for x in $HEADER_OVERRIDES; do \
-cp $HEADER_ORI/$x $HEADER_SAN/$x
+    cp $HEADER_ORI/$x $HEADER_SAN/$x
 done
 
 echo "Copy complete!"

--- a/cp_headers.sh
+++ b/cp_headers.sh
@@ -93,7 +93,7 @@ HEADER_OVERRIDES="\
 cd ../../../..
 
 source build/envsetup.sh
-lunch 50
+lunch aosp_xqdq54-trunk_staging-userdebug
 
 for x in $LINUX_HEADERS; do \
 cp $HEADER_SRC/$x $HEADER_ORI/$x

--- a/kernel-headers/asm-generic/ioctls.h
+++ b/kernel-headers/asm-generic/ioctls.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __ASM_GENERIC_IOCTLS_H
 #define __ASM_GENERIC_IOCTLS_H
 #include <linux/ioctl.h>

--- a/kernel-headers/display/drm/msm_drm_pp.h
+++ b/kernel-headers/display/drm/msm_drm_pp.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef _MSM_DRM_PP_H_
 #define _MSM_DRM_PP_H_
 #include <linux/types.h>

--- a/kernel-headers/display/drm/sde_drm.h
+++ b/kernel-headers/display/drm/sde_drm.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef _SDE_DRM_H_
 #define _SDE_DRM_H_
 #include <drm/drm.h>

--- a/kernel-headers/display/media/msm_sde_rotator.h
+++ b/kernel-headers/display/media/msm_sde_rotator.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __UAPI_MSM_SDE_ROTATOR_H__
 #define __UAPI_MSM_SDE_ROTATOR_H__
 #include <linux/videodev2.h>

--- a/kernel-headers/drm/drm.h
+++ b/kernel-headers/drm/drm.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef _DRM_H_
 #define _DRM_H_
 #ifdef __linux__
@@ -78,19 +66,19 @@ struct drm_version {
   int version_minor;
   int version_patchlevel;
   __kernel_size_t name_len;
-  char __user * name;
+  char  * name;
   __kernel_size_t date_len;
-  char __user * date;
+  char  * date;
   __kernel_size_t desc_len;
-  char __user * desc;
+  char  * desc;
 };
 struct drm_unique {
   __kernel_size_t unique_len;
-  char __user * unique;
+  char  * unique;
 };
 struct drm_list {
   int count;
-  struct drm_version __user * version;
+  struct drm_version  * version;
 };
 struct drm_block {
   int unused;
@@ -202,37 +190,37 @@ struct drm_buf_desc {
 };
 struct drm_buf_info {
   int count;
-  struct drm_buf_desc __user * list;
+  struct drm_buf_desc  * list;
 };
 struct drm_buf_free {
   int count;
-  int __user * list;
+  int  * list;
 };
 struct drm_buf_pub {
   int idx;
   int total;
   int used;
-  void __user * address;
+  void  * address;
 };
 struct drm_buf_map {
   int count;
 #ifdef __cplusplus
-  void __user * virt;
+  void  * virt;
 #else
-  void __user * __linux_virtual;
+  void  * __linux_virtual;
 #endif
-  struct drm_buf_pub __user * list;
+  struct drm_buf_pub  * list;
 };
 struct drm_dma {
   int context;
   int send_count;
-  int __user * send_indices;
-  int __user * send_sizes;
+  int  * send_indices;
+  int  * send_sizes;
   enum drm_dma_flags flags;
   int request_count;
   int request_size;
-  int __user * request_indices;
-  int __user * request_sizes;
+  int  * request_indices;
+  int  * request_sizes;
   int granted_count;
 };
 enum drm_ctx_flags {
@@ -245,7 +233,7 @@ struct drm_ctx {
 };
 struct drm_ctx_res {
   int count;
-  struct drm_ctx __user * contexts;
+  struct drm_ctx  * contexts;
 };
 struct drm_draw {
   drm_drawable_t handle;

--- a/kernel-headers/drm/drm_fourcc.h
+++ b/kernel-headers/drm/drm_fourcc.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef DRM_FOURCC_H
 #define DRM_FOURCC_H
 #include "drm.h"

--- a/kernel-headers/drm/drm_mode.h
+++ b/kernel-headers/drm/drm_mode.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef _DRM_MODE_H
 #define _DRM_MODE_H
 #include "drm.h"

--- a/kernel-headers/drm/msm_drm.h
+++ b/kernel-headers/drm/msm_drm.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __MSM_DRM_H__
 #define __MSM_DRM_H__
 #include "drm.h"

--- a/kernel-headers/linux/esoc_ctrl.h
+++ b/kernel-headers/linux/esoc_ctrl.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef _UAPI_ESOC_CTRL_H_
 #define _UAPI_ESOC_CTRL_H_
 #include <linux/types.h>

--- a/kernel-headers/linux/fb.h
+++ b/kernel-headers/linux/fb.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef _UAPI_LINUX_FB_H
 #define _UAPI_LINUX_FB_H
 #include <linux/types.h>

--- a/kernel-headers/linux/fuse.h
+++ b/kernel-headers/linux/fuse.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef _LINUX_FUSE_H
 #define _LINUX_FUSE_H
 #include <stdint.h>

--- a/kernel-headers/linux/hdmi.h
+++ b/kernel-headers/linux/hdmi.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __LINUX_HDMI_H_
 #define __LINUX_HDMI_H_
 #include <linux/types.h>

--- a/kernel-headers/linux/ion.h
+++ b/kernel-headers/linux/ion.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef _UAPI_LINUX_ION_H
 #define _UAPI_LINUX_ION_H
 #include <linux/ioctl.h>

--- a/kernel-headers/linux/ipa_qmi_service_v01.h
+++ b/kernel-headers/linux/ipa_qmi_service_v01.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef IPA_QMI_SERVICE_V01_H
 #define IPA_QMI_SERVICE_V01_H
 #include <linux/types.h>

--- a/kernel-headers/linux/mmc/ioctl.h
+++ b/kernel-headers/linux/mmc/ioctl.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef LINUX_MMC_IOCTL_H
 #define LINUX_MMC_IOCTL_H
 #include <linux/types.h>

--- a/kernel-headers/linux/msm_audio.h
+++ b/kernel-headers/linux/msm_audio.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef _UAPI_LINUX_MSM_AUDIO_H
 #define _UAPI_LINUX_MSM_AUDIO_H
 #include <linux/types.h>

--- a/kernel-headers/linux/msm_ion.h
+++ b/kernel-headers/linux/msm_ion.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef _UAPI_LINUX_MSM_ION_H
 #define _UAPI_LINUX_MSM_ION_H
 #include <linux/types.h>

--- a/kernel-headers/linux/msm_ion_ids.h
+++ b/kernel-headers/linux/msm_ion_ids.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef _MSM_ION_IDS_H
 #define _MSM_ION_IDS_H
 #define ION_BIT(nr) (1U << (nr))

--- a/kernel-headers/linux/msm_ipa.h
+++ b/kernel-headers/linux/msm_ipa.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef _UAPI_MSM_IPA_H_
 #define _UAPI_MSM_IPA_H_
 #include <stdio.h>
@@ -855,7 +843,7 @@ struct IpaDscpVlanPcpMap_t {
   uint8_t dscp[IPA_EoGRE_MAX_VLAN][IPA_EoGRE_MAX_PCP_IDX];
   uint8_t num_vlan;
   uint8_t reserved0;
-} __packed;
+} __attribute__((__packed__));
 struct ipa_ipgre_info {
   enum ipa_ip_type iptype;
   uint32_t ipv4_src;

--- a/kernel-headers/linux/msm_kgsl.h
+++ b/kernel-headers/linux/msm_kgsl.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef _UAPI_MSM_KGSL_H
 #define _UAPI_MSM_KGSL_H
 #include <linux/types.h>
@@ -352,7 +340,7 @@ struct kgsl_cmdbatch_profiling_buffer {
 #define KGSL_IOC_TYPE 0x09
 struct kgsl_device_getproperty {
   unsigned int type;
-  void __user * value;
+  void  * value;
   __kernel_size_t sizebytes;
 };
 #define IOCTL_KGSL_DEVICE_GETPROPERTY _IOWR(KGSL_IOC_TYPE, 0x2, struct kgsl_device_getproperty)
@@ -507,7 +495,7 @@ struct kgsl_timestamp_event {
   int type;
   unsigned int timestamp;
   unsigned int context_id;
-  void __user * priv;
+  void  * priv;
   __kernel_size_t len;
 };
 #define IOCTL_KGSL_TIMESTAMP_EVENT_OLD _IOW(KGSL_IOC_TYPE, 0x31, struct kgsl_timestamp_event)
@@ -575,7 +563,7 @@ struct kgsl_perfcounter_put {
 #define IOCTL_KGSL_PERFCOUNTER_PUT _IOW(KGSL_IOC_TYPE, 0x39, struct kgsl_perfcounter_put)
 struct kgsl_perfcounter_query {
   unsigned int groupid;
-  unsigned int __user * countables;
+  unsigned int  * countables;
   unsigned int count;
   unsigned int max_counters;
   unsigned int __pad[2];
@@ -587,13 +575,13 @@ struct kgsl_perfcounter_read_group {
   unsigned long long value;
 };
 struct kgsl_perfcounter_read {
-  struct kgsl_perfcounter_read_group __user * reads;
+  struct kgsl_perfcounter_read_group  * reads;
   unsigned int count;
   unsigned int __pad[2];
 };
 #define IOCTL_KGSL_PERFCOUNTER_READ _IOWR(KGSL_IOC_TYPE, 0x3B, struct kgsl_perfcounter_read)
 struct kgsl_gpumem_sync_cache_bulk {
-  unsigned int __user * id_list;
+  unsigned int  * id_list;
   unsigned int count;
   unsigned int op;
   unsigned int __pad[2];
@@ -613,7 +601,7 @@ struct kgsl_cmd_syncpoint_timeline {
 };
 struct kgsl_cmd_syncpoint {
   int type;
-  void __user * priv;
+  void  * priv;
   __kernel_size_t size;
 };
 #define KGSL_IBDESC_MEMLIST 0x1
@@ -621,9 +609,9 @@ struct kgsl_cmd_syncpoint {
 struct kgsl_submit_commands {
   unsigned int context_id;
   unsigned int flags;
-  struct kgsl_ibdesc __user * cmdlist;
+  struct kgsl_ibdesc  * cmdlist;
   unsigned int numcmds;
-  struct kgsl_cmd_syncpoint __user * synclist;
+  struct kgsl_cmd_syncpoint  * synclist;
   unsigned int numsyncs;
   unsigned int timestamp;
   unsigned int __pad[4];
@@ -632,7 +620,7 @@ struct kgsl_submit_commands {
 struct kgsl_device_constraint {
   unsigned int type;
   unsigned int context_id;
-  void __user * data;
+  void  * data;
   __kernel_size_t size;
 };
 #define KGSL_CONSTRAINT_NONE 0
@@ -685,7 +673,7 @@ struct kgsl_gpuobj_alloc {
 #define IOCTL_KGSL_GPUOBJ_ALLOC _IOWR(KGSL_IOC_TYPE, 0x45, struct kgsl_gpuobj_alloc)
 struct kgsl_gpuobj_free {
   __u64 flags;
-  __u64 __user priv;
+  __u64  priv;
   unsigned int id;
   unsigned int type;
   unsigned int len;
@@ -711,7 +699,7 @@ struct kgsl_gpuobj_info {
 };
 #define IOCTL_KGSL_GPUOBJ_INFO _IOWR(KGSL_IOC_TYPE, 0x47, struct kgsl_gpuobj_info)
 struct kgsl_gpuobj_import {
-  __u64 __user priv;
+  __u64  priv;
   __u64 priv_len;
   __u64 flags;
   unsigned int type;
@@ -731,7 +719,7 @@ struct kgsl_gpuobj_sync_obj {
   unsigned int op;
 };
 struct kgsl_gpuobj_sync {
-  __u64 __user objs;
+  __u64  objs;
   unsigned int obj_len;
   unsigned int count;
 };
@@ -744,19 +732,19 @@ struct kgsl_command_object {
   unsigned int id;
 };
 struct kgsl_command_syncpoint {
-  __u64 __user priv;
+  __u64  priv;
   __u64 size;
   unsigned int type;
 };
 struct kgsl_gpu_command {
   __u64 flags;
-  __u64 __user cmdlist;
+  __u64  cmdlist;
   unsigned int cmdsize;
   unsigned int numcmds;
-  __u64 __user objlist;
+  __u64  objlist;
   unsigned int objsize;
   unsigned int numobjs;
-  __u64 __user synclist;
+  __u64  synclist;
   unsigned int syncsize;
   unsigned int numsyncs;
   unsigned int context_id;
@@ -764,7 +752,7 @@ struct kgsl_gpu_command {
 };
 #define IOCTL_KGSL_GPU_COMMAND _IOWR(KGSL_IOC_TYPE, 0x4A, struct kgsl_gpu_command)
 struct kgsl_preemption_counters_query {
-  __u64 __user counters;
+  __u64  counters;
   unsigned int size_user;
   unsigned int size_priority_level;
   unsigned int max_priority_level;
@@ -811,7 +799,7 @@ struct kgsl_sparse_binding_object {
   unsigned int id;
 };
 struct kgsl_sparse_bind {
-  __u64 __user list;
+  __u64  list;
   unsigned int id;
   unsigned int size;
   unsigned int count;
@@ -819,8 +807,8 @@ struct kgsl_sparse_bind {
 #define IOCTL_KGSL_SPARSE_BIND _IOW(KGSL_IOC_TYPE, 0x54, struct kgsl_sparse_bind)
 struct kgsl_gpu_sparse_command {
   __u64 flags;
-  __u64 __user sparselist;
-  __u64 __user synclist;
+  __u64  sparselist;
+  __u64  synclist;
   unsigned int sparsesize;
   unsigned int numsparse;
   unsigned int syncsize;
@@ -954,10 +942,10 @@ struct kgsl_fault_report {
 #define IOCTL_KGSL_GET_FAULT_REPORT _IOWR(KGSL_IOC_TYPE, 0x5E, struct kgsl_fault_report)
 struct kgsl_recurring_command {
   __u64 flags;
-  __u64 __user cmdlist;
+  __u64  cmdlist;
   __u32 cmdsize;
   __u32 numcmds;
-  __u64 __user objlist;
+  __u64  objlist;
   __u32 objsize;
   __u32 numobjs;
   __u32 context_id;

--- a/kernel-headers/linux/msm_rmnet.h
+++ b/kernel-headers/linux/msm_rmnet.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef _UAPI_MSM_RMNET_H_
 #define _UAPI_MSM_RMNET_H_
 #include <linux/types.h>

--- a/kernel-headers/linux/netlink.h
+++ b/kernel-headers/linux/netlink.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef _UAPI__LINUX_NETLINK_H
 #define _UAPI__LINUX_NETLINK_H
 #include <linux/const.h>

--- a/kernel-headers/linux/qseecom.h
+++ b/kernel-headers/linux/qseecom.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef _QSEECOM_H_
 #define _QSEECOM_H_
 #include <linux/types.h>

--- a/kernel-headers/linux/rmnet_data.h
+++ b/kernel-headers/linux/rmnet_data.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef _RMNET_DATA_H_
 #define _RMNET_DATA_H_
 #include <linux/types.h>

--- a/kernel-headers/linux/rmnet_ipa_fd_ioctl.h
+++ b/kernel-headers/linux/rmnet_ipa_fd_ioctl.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef _RMNET_IPA_FD_IOCTL_H
 #define _RMNET_IPA_FD_IOCTL_H
 #include <linux/ioctl.h>

--- a/kernel-headers/linux/smcinvoke.h
+++ b/kernel-headers/linux/smcinvoke.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef _UAPI_SMCINVOKE_H_
 #define _UAPI_SMCINVOKE_H_
 #include <linux/types.h>

--- a/kernel-headers/linux/spcom.h
+++ b/kernel-headers/linux/spcom.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef _UAPI_SPCOM_H_
 #define _UAPI_SPCOM_H_
 #include <linux/types.h>
@@ -51,26 +39,26 @@ enum spcom_poll_events {
 struct spcom_user_command {
   enum spcom_cmd_id cmd_id;
   __u32 arg;
-} __packed;
+} __attribute__((__packed__));
 struct spcom_send_command {
   enum spcom_cmd_id cmd_id;
   __u32 timeout_msec;
   __u32 buf_size;
   char buf[0];
-} __packed;
+} __attribute__((__packed__));
 struct spcom_user_create_channel_command {
   enum spcom_cmd_id cmd_id;
   char ch_name[SPCOM_CHANNEL_NAME_SIZE];
 #define SPCOM_IS_SHARABLE_SUPPORTED
   _Bool is_sharable;
-} __packed;
+} __attribute__((__packed__));
 #define SPCOM_USER_RESTART_SP_CMD
 struct spcom_user_restart_sp_command {
   enum spcom_cmd_id cmd_id;
   __u32 arg;
 #define SPCOM_IS_UPDATED_SUPPORETED
   __u32 is_updated;
-} __packed;
+} __attribute__((__packed__));
 #define SPCOM_MAX_ION_BUF 4
 struct spcom_ion_info {
   __s32 fd;
@@ -83,14 +71,14 @@ struct spcom_ion_handle {
 struct spcom_rmb_error_info {
   __u32 rmb_error;
   __u32 padding;
-} __packed;
+} __attribute__((__packed__));
 struct spcom_user_send_modified_command {
   enum spcom_cmd_id cmd_id;
   struct spcom_ion_info ion_info[SPCOM_MAX_ION_BUF];
   __u32 timeout_msec;
   __u32 buf_size;
   char buf[0];
-} __packed;
+} __attribute__((__packed__));
 enum {
   SPCOM_IONFD_CMD,
   SPCOM_POLL_CMD,
@@ -104,7 +92,7 @@ struct spcom_poll_param {
   _Bool wait;
   enum spcom_poll_cmd_id cmd_id;
   int retval;
-} __packed;
+} __attribute__((__packed__));
 #define SPCOM_IOCTL_MAGIC 'S'
 #define SPCOM_GET_IONFD _IOR(SPCOM_IOCTL_MAGIC, SPCOM_IONFD_CMD, struct spcom_ion_handle)
 #define SPCOM_SET_IONFD _IOW(SPCOM_IOCTL_MAGIC, SPCOM_IONFD_CMD, struct spcom_ion_handle)
@@ -133,42 +121,42 @@ enum spcom_ioctl_enum {
 struct spcom_dma_buf_info {
   __s32 fd;
   __u32 offset;
-} __packed;
+} __attribute__((__packed__));
 struct spcom_dma_buf_info_table {
   struct spcom_dma_buf_info info[SPCOM_MAX_DMA_BUF];
-} __packed;
+} __attribute__((__packed__));
 struct spcom_ioctl_poll_event {
   __u32 event_id;
   __u32 wait;
   __s32 retval;
   __u32 padding;
-} __packed;
+} __attribute__((__packed__));
 struct spcom_ioctl_ch {
   char ch_name[SPCOM_CHANNEL_NAME_SIZE];
-} __packed;
+} __attribute__((__packed__));
 struct spcom_ioctl_message {
   char ch_name[SPCOM_CHANNEL_NAME_SIZE];
   __u32 timeout_msec;
   __u32 buffer_size;
   char buffer[0];
-} __packed;
+} __attribute__((__packed__));
 struct spcom_ioctl_modified_message {
   char ch_name[SPCOM_CHANNEL_NAME_SIZE];
   __u32 timeout_msec;
   __u32 buffer_size;
   struct spcom_dma_buf_info info[SPCOM_MAX_DMA_BUF];
   char buffer[0];
-} __packed;
+} __attribute__((__packed__));
 struct spcom_ioctl_next_request_size {
   char ch_name[SPCOM_CHANNEL_NAME_SIZE];
   __u32 size;
   __u32 padding;
-} __packed;
+} __attribute__((__packed__));
 struct spcom_ioctl_dmabuf_lock {
   char ch_name[SPCOM_CHANNEL_NAME_SIZE];
   __s32 fd;
   __u32 padding;
-} __packed;
+} __attribute__((__packed__));
 #define SPCOM_IOCTL_STATE_POLL _IOWR(SPCOM_IOCTL_MAGIC, SPCOM_IOCTL_STATE_POLL_CMD, struct spcom_ioctl_poll_event)
 #define SPCOM_IOCTL_SHARED_CH_CREATE _IOW(SPCOM_IOCTL_MAGIC, SPCOM_IOCTL_SHARED_CH_CREATE_CMD, struct spcom_ioctl_ch)
 #define SPCOM_IOCTL_CH_REGISTER _IOW(SPCOM_IOCTL_MAGIC, SPCOM_IOCTL_CH_REGISTER_CMD, struct spcom_ioctl_ch)

--- a/kernel-headers/linux/v4l2-common.h
+++ b/kernel-headers/linux/v4l2-common.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __V4L2_COMMON__
 #define __V4L2_COMMON__
 #include <linux/types.h>

--- a/kernel-headers/linux/v4l2-controls.h
+++ b/kernel-headers/linux/v4l2-controls.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __LINUX_V4L2_CONTROLS_H
 #define __LINUX_V4L2_CONTROLS_H
 #include <linux/const.h>

--- a/kernel-headers/linux/v4l2-mediabus.h
+++ b/kernel-headers/linux/v4l2-mediabus.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __LINUX_V4L2_MEDIABUS_H
 #define __LINUX_V4L2_MEDIABUS_H
 #include <linux/media-bus-format.h>

--- a/kernel-headers/linux/videodev2.h
+++ b/kernel-headers/linux/videodev2.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef _UAPI__LINUX_VIDEODEV2_H
 #define _UAPI__LINUX_VIDEODEV2_H
 #include <linux/time.h>
@@ -633,7 +621,7 @@ struct v4l2_framebuffer {
 #define V4L2_FBUF_FLAG_SRC_CHROMAKEY 0x0040
 struct v4l2_clip {
   struct v4l2_rect c;
-  struct v4l2_clip __user * next;
+  struct v4l2_clip  * next;
 };
 struct v4l2_window {
   struct v4l2_rect w;
@@ -641,7 +629,7 @@ struct v4l2_window {
   __u32 chromakey;
   struct v4l2_clip * clips;
   __u32 clipcount;
-  void __user * bitmap;
+  void  * bitmap;
   __u8 global_alpha;
 };
 struct v4l2_captureparm {
@@ -878,23 +866,23 @@ struct v4l2_ext_control {
   union {
     __s32 value;
     __s64 value64;
-    char __user * string;
-    __u8 __user * p_u8;
-    __u16 __user * p_u16;
-    __u32 __user * p_u32;
-    struct v4l2_area __user * p_area;
-    struct v4l2_ctrl_h264_sps __user * p_h264_sps;
+    char  * string;
+    __u8  * p_u8;
+    __u16  * p_u16;
+    __u32  * p_u32;
+    struct v4l2_area  * p_area;
+    struct v4l2_ctrl_h264_sps  * p_h264_sps;
     struct v4l2_ctrl_h264_pps * p_h264_pps;
-    struct v4l2_ctrl_h264_scaling_matrix __user * p_h264_scaling_matrix;
-    struct v4l2_ctrl_h264_pred_weights __user * p_h264_pred_weights;
-    struct v4l2_ctrl_h264_slice_params __user * p_h264_slice_params;
-    struct v4l2_ctrl_h264_decode_params __user * p_h264_decode_params;
-    struct v4l2_ctrl_fwht_params __user * p_fwht_params;
-    struct v4l2_ctrl_vp8_frame __user * p_vp8_frame;
-    struct v4l2_ctrl_mpeg2_sequence __user * p_mpeg2_sequence;
-    struct v4l2_ctrl_mpeg2_picture __user * p_mpeg2_picture;
-    struct v4l2_ctrl_mpeg2_quantisation __user * p_mpeg2_quantisation;
-    void __user * ptr;
+    struct v4l2_ctrl_h264_scaling_matrix  * p_h264_scaling_matrix;
+    struct v4l2_ctrl_h264_pred_weights  * p_h264_pred_weights;
+    struct v4l2_ctrl_h264_slice_params  * p_h264_slice_params;
+    struct v4l2_ctrl_h264_decode_params  * p_h264_decode_params;
+    struct v4l2_ctrl_fwht_params  * p_fwht_params;
+    struct v4l2_ctrl_vp8_frame  * p_vp8_frame;
+    struct v4l2_ctrl_mpeg2_sequence  * p_mpeg2_sequence;
+    struct v4l2_ctrl_mpeg2_picture  * p_mpeg2_picture;
+    struct v4l2_ctrl_mpeg2_quantisation  * p_mpeg2_quantisation;
+    void  * ptr;
   };
 } __attribute__((packed));
 struct v4l2_ext_controls {

--- a/kernel-headers/media/cam_cpas.h
+++ b/kernel-headers/media/cam_cpas.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __UAPI_CAM_CPAS_H__
 #define __UAPI_CAM_CPAS_H__
 #include <media/cam_defs.h>

--- a/kernel-headers/media/cam_cre.h
+++ b/kernel-headers/media/cam_cre.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __UAPI_CAM_CRE_H__
 #define __UAPI_CAM_CRE_H__
 #include <media/cam_defs.h>

--- a/kernel-headers/media/cam_custom.h
+++ b/kernel-headers/media/cam_custom.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __UAPI_CAM_CUSTOM_H__
 #define __UAPI_CAM_CUSTOM_H__
 #include <media/cam_defs.h>

--- a/kernel-headers/media/cam_defs.h
+++ b/kernel-headers/media/cam_defs.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __UAPI_CAM_DEFS_H__
 #define __UAPI_CAM_DEFS_H__
 #include <linux/videodev2.h>

--- a/kernel-headers/media/cam_fd.h
+++ b/kernel-headers/media/cam_fd.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __UAPI_CAM_FD_H__
 #define __UAPI_CAM_FD_H__
 #include <media/cam_defs.h>

--- a/kernel-headers/media/cam_icp.h
+++ b/kernel-headers/media/cam_icp.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __UAPI_CAM_ICP_H__
 #define __UAPI_CAM_ICP_H__
 #include <media/cam_defs.h>

--- a/kernel-headers/media/cam_isp.h
+++ b/kernel-headers/media/cam_isp.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __UAPI_CAM_ISP_H__
 #define __UAPI_CAM_ISP_H__
 #include <media/cam_defs.h>

--- a/kernel-headers/media/cam_isp_ife.h
+++ b/kernel-headers/media/cam_isp_ife.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __UAPI_CAM_ISP_IFE_H__
 #define __UAPI_CAM_ISP_IFE_H__
 #define CAM_ISP_IFE_OUT_RES_BASE 0x3000

--- a/kernel-headers/media/cam_isp_sfe.h
+++ b/kernel-headers/media/cam_isp_sfe.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __UAPI_CAM_ISP_SFE_H__
 #define __UAPI_CAM_ISP_SFE_H__
 #define CAM_ISP_SFE_OUT_RES_BASE 0x6000

--- a/kernel-headers/media/cam_isp_tfe.h
+++ b/kernel-headers/media/cam_isp_tfe.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __UAPI_CAM_ISP_TFE_H__
 #define __UAPI_CAM_ISP_TFE_H__
 #define CAM_ISP_TFE_OUT_RES_BASE 0x1

--- a/kernel-headers/media/cam_isp_vfe.h
+++ b/kernel-headers/media/cam_isp_vfe.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __UAPI_CAM_ISP_VFE_H__
 #define __UAPI_CAM_ISP_VFE_H__
 #define CAM_ISP_VFE_OUT_RES_BASE 0x1000

--- a/kernel-headers/media/cam_jpeg.h
+++ b/kernel-headers/media/cam_jpeg.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __UAPI_CAM_JPEG_H__
 #define __UAPI_CAM_JPEG_H__
 #include <media/cam_defs.h>

--- a/kernel-headers/media/cam_lrme.h
+++ b/kernel-headers/media/cam_lrme.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __UAPI_CAM_LRME_H__
 #define __UAPI_CAM_LRME_H__
 #include <media/cam_defs.h>

--- a/kernel-headers/media/cam_ope.h
+++ b/kernel-headers/media/cam_ope.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __UAPI_OPE_H__
 #define __UAPI_OPE_H__
 #include <media/cam_defs.h>

--- a/kernel-headers/media/cam_req_mgr.h
+++ b/kernel-headers/media/cam_req_mgr.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __UAPI_LINUX_CAM_REQ_MGR_H
 #define __UAPI_LINUX_CAM_REQ_MGR_H
 #include <linux/videodev2.h>

--- a/kernel-headers/media/cam_sensor.h
+++ b/kernel-headers/media/cam_sensor.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __UAPI_CAM_SENSOR_H__
 #define __UAPI_CAM_SENSOR_H__
 #include <linux/types.h>

--- a/kernel-headers/media/cam_sync.h
+++ b/kernel-headers/media/cam_sync.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __UAPI_CAM_SYNC_H__
 #define __UAPI_CAM_SYNC_H__
 #include <linux/videodev2.h>

--- a/kernel-headers/media/cam_tfe.h
+++ b/kernel-headers/media/cam_tfe.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __UAPI_CAM_TFE_H__
 #define __UAPI_CAM_TFE_H__
 #include <media/cam_defs.h>

--- a/kernel-headers/misc/adsp_sleepmon.h
+++ b/kernel-headers/misc/adsp_sleepmon.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __QCOM_ADSPSLEEPMON_H__
 #define __QCOM_ADSPSLEEPMON_H__
 #include <linux/types.h>

--- a/kernel-headers/sound/asound.h
+++ b/kernel-headers/sound/asound.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef _UAPI__SOUND_ASOUND_H
 #define _UAPI__SOUND_ASOUND_H
 #ifdef __linux__
@@ -96,7 +84,7 @@ struct snd_hwdep_dsp_status {
 struct snd_hwdep_dsp_image {
   unsigned int index;
   unsigned char name[64];
-  unsigned char __user * image;
+  unsigned char  * image;
   size_t length;
   unsigned long driver_data;
 };
@@ -125,64 +113,64 @@ enum {
   SNDRV_PCM_STREAM_LAST = SNDRV_PCM_STREAM_CAPTURE,
 };
 typedef int __bitwise snd_pcm_access_t;
-#define SNDRV_PCM_ACCESS_MMAP_INTERLEAVED ((__force snd_pcm_access_t) 0)
-#define SNDRV_PCM_ACCESS_MMAP_NONINTERLEAVED ((__force snd_pcm_access_t) 1)
-#define SNDRV_PCM_ACCESS_MMAP_COMPLEX ((__force snd_pcm_access_t) 2)
-#define SNDRV_PCM_ACCESS_RW_INTERLEAVED ((__force snd_pcm_access_t) 3)
-#define SNDRV_PCM_ACCESS_RW_NONINTERLEAVED ((__force snd_pcm_access_t) 4)
+#define SNDRV_PCM_ACCESS_MMAP_INTERLEAVED (( snd_pcm_access_t) 0)
+#define SNDRV_PCM_ACCESS_MMAP_NONINTERLEAVED (( snd_pcm_access_t) 1)
+#define SNDRV_PCM_ACCESS_MMAP_COMPLEX (( snd_pcm_access_t) 2)
+#define SNDRV_PCM_ACCESS_RW_INTERLEAVED (( snd_pcm_access_t) 3)
+#define SNDRV_PCM_ACCESS_RW_NONINTERLEAVED (( snd_pcm_access_t) 4)
 #define SNDRV_PCM_ACCESS_LAST SNDRV_PCM_ACCESS_RW_NONINTERLEAVED
 typedef int __bitwise snd_pcm_format_t;
-#define SNDRV_PCM_FORMAT_S8 ((__force snd_pcm_format_t) 0)
-#define SNDRV_PCM_FORMAT_U8 ((__force snd_pcm_format_t) 1)
-#define SNDRV_PCM_FORMAT_S16_LE ((__force snd_pcm_format_t) 2)
-#define SNDRV_PCM_FORMAT_S16_BE ((__force snd_pcm_format_t) 3)
-#define SNDRV_PCM_FORMAT_U16_LE ((__force snd_pcm_format_t) 4)
-#define SNDRV_PCM_FORMAT_U16_BE ((__force snd_pcm_format_t) 5)
-#define SNDRV_PCM_FORMAT_S24_LE ((__force snd_pcm_format_t) 6)
-#define SNDRV_PCM_FORMAT_S24_BE ((__force snd_pcm_format_t) 7)
-#define SNDRV_PCM_FORMAT_U24_LE ((__force snd_pcm_format_t) 8)
-#define SNDRV_PCM_FORMAT_U24_BE ((__force snd_pcm_format_t) 9)
-#define SNDRV_PCM_FORMAT_S32_LE ((__force snd_pcm_format_t) 10)
-#define SNDRV_PCM_FORMAT_S32_BE ((__force snd_pcm_format_t) 11)
-#define SNDRV_PCM_FORMAT_U32_LE ((__force snd_pcm_format_t) 12)
-#define SNDRV_PCM_FORMAT_U32_BE ((__force snd_pcm_format_t) 13)
-#define SNDRV_PCM_FORMAT_FLOAT_LE ((__force snd_pcm_format_t) 14)
-#define SNDRV_PCM_FORMAT_FLOAT_BE ((__force snd_pcm_format_t) 15)
-#define SNDRV_PCM_FORMAT_FLOAT64_LE ((__force snd_pcm_format_t) 16)
-#define SNDRV_PCM_FORMAT_FLOAT64_BE ((__force snd_pcm_format_t) 17)
-#define SNDRV_PCM_FORMAT_IEC958_SUBFRAME_LE ((__force snd_pcm_format_t) 18)
-#define SNDRV_PCM_FORMAT_IEC958_SUBFRAME_BE ((__force snd_pcm_format_t) 19)
-#define SNDRV_PCM_FORMAT_MU_LAW ((__force snd_pcm_format_t) 20)
-#define SNDRV_PCM_FORMAT_A_LAW ((__force snd_pcm_format_t) 21)
-#define SNDRV_PCM_FORMAT_IMA_ADPCM ((__force snd_pcm_format_t) 22)
-#define SNDRV_PCM_FORMAT_MPEG ((__force snd_pcm_format_t) 23)
-#define SNDRV_PCM_FORMAT_GSM ((__force snd_pcm_format_t) 24)
-#define SNDRV_PCM_FORMAT_S20_LE ((__force snd_pcm_format_t) 25)
-#define SNDRV_PCM_FORMAT_S20_BE ((__force snd_pcm_format_t) 26)
-#define SNDRV_PCM_FORMAT_U20_LE ((__force snd_pcm_format_t) 27)
-#define SNDRV_PCM_FORMAT_U20_BE ((__force snd_pcm_format_t) 28)
-#define SNDRV_PCM_FORMAT_SPECIAL ((__force snd_pcm_format_t) 31)
-#define SNDRV_PCM_FORMAT_S24_3LE ((__force snd_pcm_format_t) 32)
-#define SNDRV_PCM_FORMAT_S24_3BE ((__force snd_pcm_format_t) 33)
-#define SNDRV_PCM_FORMAT_U24_3LE ((__force snd_pcm_format_t) 34)
-#define SNDRV_PCM_FORMAT_U24_3BE ((__force snd_pcm_format_t) 35)
-#define SNDRV_PCM_FORMAT_S20_3LE ((__force snd_pcm_format_t) 36)
-#define SNDRV_PCM_FORMAT_S20_3BE ((__force snd_pcm_format_t) 37)
-#define SNDRV_PCM_FORMAT_U20_3LE ((__force snd_pcm_format_t) 38)
-#define SNDRV_PCM_FORMAT_U20_3BE ((__force snd_pcm_format_t) 39)
-#define SNDRV_PCM_FORMAT_S18_3LE ((__force snd_pcm_format_t) 40)
-#define SNDRV_PCM_FORMAT_S18_3BE ((__force snd_pcm_format_t) 41)
-#define SNDRV_PCM_FORMAT_U18_3LE ((__force snd_pcm_format_t) 42)
-#define SNDRV_PCM_FORMAT_U18_3BE ((__force snd_pcm_format_t) 43)
-#define SNDRV_PCM_FORMAT_G723_24 ((__force snd_pcm_format_t) 44)
-#define SNDRV_PCM_FORMAT_G723_24_1B ((__force snd_pcm_format_t) 45)
-#define SNDRV_PCM_FORMAT_G723_40 ((__force snd_pcm_format_t) 46)
-#define SNDRV_PCM_FORMAT_G723_40_1B ((__force snd_pcm_format_t) 47)
-#define SNDRV_PCM_FORMAT_DSD_U8 ((__force snd_pcm_format_t) 48)
-#define SNDRV_PCM_FORMAT_DSD_U16_LE ((__force snd_pcm_format_t) 49)
-#define SNDRV_PCM_FORMAT_DSD_U32_LE ((__force snd_pcm_format_t) 50)
-#define SNDRV_PCM_FORMAT_DSD_U16_BE ((__force snd_pcm_format_t) 51)
-#define SNDRV_PCM_FORMAT_DSD_U32_BE ((__force snd_pcm_format_t) 52)
+#define SNDRV_PCM_FORMAT_S8 (( snd_pcm_format_t) 0)
+#define SNDRV_PCM_FORMAT_U8 (( snd_pcm_format_t) 1)
+#define SNDRV_PCM_FORMAT_S16_LE (( snd_pcm_format_t) 2)
+#define SNDRV_PCM_FORMAT_S16_BE (( snd_pcm_format_t) 3)
+#define SNDRV_PCM_FORMAT_U16_LE (( snd_pcm_format_t) 4)
+#define SNDRV_PCM_FORMAT_U16_BE (( snd_pcm_format_t) 5)
+#define SNDRV_PCM_FORMAT_S24_LE (( snd_pcm_format_t) 6)
+#define SNDRV_PCM_FORMAT_S24_BE (( snd_pcm_format_t) 7)
+#define SNDRV_PCM_FORMAT_U24_LE (( snd_pcm_format_t) 8)
+#define SNDRV_PCM_FORMAT_U24_BE (( snd_pcm_format_t) 9)
+#define SNDRV_PCM_FORMAT_S32_LE (( snd_pcm_format_t) 10)
+#define SNDRV_PCM_FORMAT_S32_BE (( snd_pcm_format_t) 11)
+#define SNDRV_PCM_FORMAT_U32_LE (( snd_pcm_format_t) 12)
+#define SNDRV_PCM_FORMAT_U32_BE (( snd_pcm_format_t) 13)
+#define SNDRV_PCM_FORMAT_FLOAT_LE (( snd_pcm_format_t) 14)
+#define SNDRV_PCM_FORMAT_FLOAT_BE (( snd_pcm_format_t) 15)
+#define SNDRV_PCM_FORMAT_FLOAT64_LE (( snd_pcm_format_t) 16)
+#define SNDRV_PCM_FORMAT_FLOAT64_BE (( snd_pcm_format_t) 17)
+#define SNDRV_PCM_FORMAT_IEC958_SUBFRAME_LE (( snd_pcm_format_t) 18)
+#define SNDRV_PCM_FORMAT_IEC958_SUBFRAME_BE (( snd_pcm_format_t) 19)
+#define SNDRV_PCM_FORMAT_MU_LAW (( snd_pcm_format_t) 20)
+#define SNDRV_PCM_FORMAT_A_LAW (( snd_pcm_format_t) 21)
+#define SNDRV_PCM_FORMAT_IMA_ADPCM (( snd_pcm_format_t) 22)
+#define SNDRV_PCM_FORMAT_MPEG (( snd_pcm_format_t) 23)
+#define SNDRV_PCM_FORMAT_GSM (( snd_pcm_format_t) 24)
+#define SNDRV_PCM_FORMAT_S20_LE (( snd_pcm_format_t) 25)
+#define SNDRV_PCM_FORMAT_S20_BE (( snd_pcm_format_t) 26)
+#define SNDRV_PCM_FORMAT_U20_LE (( snd_pcm_format_t) 27)
+#define SNDRV_PCM_FORMAT_U20_BE (( snd_pcm_format_t) 28)
+#define SNDRV_PCM_FORMAT_SPECIAL (( snd_pcm_format_t) 31)
+#define SNDRV_PCM_FORMAT_S24_3LE (( snd_pcm_format_t) 32)
+#define SNDRV_PCM_FORMAT_S24_3BE (( snd_pcm_format_t) 33)
+#define SNDRV_PCM_FORMAT_U24_3LE (( snd_pcm_format_t) 34)
+#define SNDRV_PCM_FORMAT_U24_3BE (( snd_pcm_format_t) 35)
+#define SNDRV_PCM_FORMAT_S20_3LE (( snd_pcm_format_t) 36)
+#define SNDRV_PCM_FORMAT_S20_3BE (( snd_pcm_format_t) 37)
+#define SNDRV_PCM_FORMAT_U20_3LE (( snd_pcm_format_t) 38)
+#define SNDRV_PCM_FORMAT_U20_3BE (( snd_pcm_format_t) 39)
+#define SNDRV_PCM_FORMAT_S18_3LE (( snd_pcm_format_t) 40)
+#define SNDRV_PCM_FORMAT_S18_3BE (( snd_pcm_format_t) 41)
+#define SNDRV_PCM_FORMAT_U18_3LE (( snd_pcm_format_t) 42)
+#define SNDRV_PCM_FORMAT_U18_3BE (( snd_pcm_format_t) 43)
+#define SNDRV_PCM_FORMAT_G723_24 (( snd_pcm_format_t) 44)
+#define SNDRV_PCM_FORMAT_G723_24_1B (( snd_pcm_format_t) 45)
+#define SNDRV_PCM_FORMAT_G723_40 (( snd_pcm_format_t) 46)
+#define SNDRV_PCM_FORMAT_G723_40_1B (( snd_pcm_format_t) 47)
+#define SNDRV_PCM_FORMAT_DSD_U8 (( snd_pcm_format_t) 48)
+#define SNDRV_PCM_FORMAT_DSD_U16_LE (( snd_pcm_format_t) 49)
+#define SNDRV_PCM_FORMAT_DSD_U32_LE (( snd_pcm_format_t) 50)
+#define SNDRV_PCM_FORMAT_DSD_U16_BE (( snd_pcm_format_t) 51)
+#define SNDRV_PCM_FORMAT_DSD_U32_BE (( snd_pcm_format_t) 52)
 #define SNDRV_PCM_FORMAT_LAST SNDRV_PCM_FORMAT_DSD_U32_BE
 #define SNDRV_PCM_FORMAT_FIRST SNDRV_PCM_FORMAT_S8
 #ifdef SNDRV_LITTLE_ENDIAN
@@ -212,7 +200,7 @@ typedef int __bitwise snd_pcm_format_t;
 #define SNDRV_PCM_FORMAT_U20 SNDRV_PCM_FORMAT_U20_BE
 #endif
 typedef int __bitwise snd_pcm_subformat_t;
-#define SNDRV_PCM_SUBFORMAT_STD ((__force snd_pcm_subformat_t) 0)
+#define SNDRV_PCM_SUBFORMAT_STD (( snd_pcm_subformat_t) 0)
 #define SNDRV_PCM_SUBFORMAT_LAST SNDRV_PCM_SUBFORMAT_STD
 #define SNDRV_PCM_INFO_MMAP 0x00000001
 #define SNDRV_PCM_INFO_MMAP_VALID 0x00000002
@@ -242,15 +230,15 @@ typedef int __bitwise snd_pcm_subformat_t;
 #define __SND_STRUCT_TIME64
 #endif
 typedef int __bitwise snd_pcm_state_t;
-#define SNDRV_PCM_STATE_OPEN ((__force snd_pcm_state_t) 0)
-#define SNDRV_PCM_STATE_SETUP ((__force snd_pcm_state_t) 1)
-#define SNDRV_PCM_STATE_PREPARED ((__force snd_pcm_state_t) 2)
-#define SNDRV_PCM_STATE_RUNNING ((__force snd_pcm_state_t) 3)
-#define SNDRV_PCM_STATE_XRUN ((__force snd_pcm_state_t) 4)
-#define SNDRV_PCM_STATE_DRAINING ((__force snd_pcm_state_t) 5)
-#define SNDRV_PCM_STATE_PAUSED ((__force snd_pcm_state_t) 6)
-#define SNDRV_PCM_STATE_SUSPENDED ((__force snd_pcm_state_t) 7)
-#define SNDRV_PCM_STATE_DISCONNECTED ((__force snd_pcm_state_t) 8)
+#define SNDRV_PCM_STATE_OPEN (( snd_pcm_state_t) 0)
+#define SNDRV_PCM_STATE_SETUP (( snd_pcm_state_t) 1)
+#define SNDRV_PCM_STATE_PREPARED (( snd_pcm_state_t) 2)
+#define SNDRV_PCM_STATE_RUNNING (( snd_pcm_state_t) 3)
+#define SNDRV_PCM_STATE_XRUN (( snd_pcm_state_t) 4)
+#define SNDRV_PCM_STATE_DRAINING (( snd_pcm_state_t) 5)
+#define SNDRV_PCM_STATE_PAUSED (( snd_pcm_state_t) 6)
+#define SNDRV_PCM_STATE_SUSPENDED (( snd_pcm_state_t) 7)
+#define SNDRV_PCM_STATE_DISCONNECTED (( snd_pcm_state_t) 8)
 #define SNDRV_PCM_STATE_LAST SNDRV_PCM_STATE_DISCONNECTED
 enum {
   SNDRV_PCM_MMAP_OFFSET_DATA = 0x00000000,
@@ -474,12 +462,12 @@ struct __snd_pcm_sync_ptr64 {
 };
 struct snd_xferi {
   snd_pcm_sframes_t result;
-  void __user * buf;
+  void  * buf;
   snd_pcm_uframes_t frames;
 };
 struct snd_xfern {
   snd_pcm_sframes_t result;
-  void __user * __user * bufs;
+  void  *  * bufs;
   snd_pcm_uframes_t frames;
 };
 enum {
@@ -604,7 +592,7 @@ struct snd_rawmidi_framing_tstamp {
   __u32 tv_nsec;
   __u64 tv_sec;
   __u8 data[SNDRV_RAWMIDI_FRAMING_DATA_LENGTH];
-} __packed;
+} __attribute__((__packed__));
 struct snd_rawmidi_params {
   int stream;
   size_t buffer_size;
@@ -775,22 +763,22 @@ struct snd_ctl_card_info {
   unsigned char components[128];
 };
 typedef int __bitwise snd_ctl_elem_type_t;
-#define SNDRV_CTL_ELEM_TYPE_NONE ((__force snd_ctl_elem_type_t) 0)
-#define SNDRV_CTL_ELEM_TYPE_BOOLEAN ((__force snd_ctl_elem_type_t) 1)
-#define SNDRV_CTL_ELEM_TYPE_INTEGER ((__force snd_ctl_elem_type_t) 2)
-#define SNDRV_CTL_ELEM_TYPE_ENUMERATED ((__force snd_ctl_elem_type_t) 3)
-#define SNDRV_CTL_ELEM_TYPE_BYTES ((__force snd_ctl_elem_type_t) 4)
-#define SNDRV_CTL_ELEM_TYPE_IEC958 ((__force snd_ctl_elem_type_t) 5)
-#define SNDRV_CTL_ELEM_TYPE_INTEGER64 ((__force snd_ctl_elem_type_t) 6)
+#define SNDRV_CTL_ELEM_TYPE_NONE (( snd_ctl_elem_type_t) 0)
+#define SNDRV_CTL_ELEM_TYPE_BOOLEAN (( snd_ctl_elem_type_t) 1)
+#define SNDRV_CTL_ELEM_TYPE_INTEGER (( snd_ctl_elem_type_t) 2)
+#define SNDRV_CTL_ELEM_TYPE_ENUMERATED (( snd_ctl_elem_type_t) 3)
+#define SNDRV_CTL_ELEM_TYPE_BYTES (( snd_ctl_elem_type_t) 4)
+#define SNDRV_CTL_ELEM_TYPE_IEC958 (( snd_ctl_elem_type_t) 5)
+#define SNDRV_CTL_ELEM_TYPE_INTEGER64 (( snd_ctl_elem_type_t) 6)
 #define SNDRV_CTL_ELEM_TYPE_LAST SNDRV_CTL_ELEM_TYPE_INTEGER64
 typedef int __bitwise snd_ctl_elem_iface_t;
-#define SNDRV_CTL_ELEM_IFACE_CARD ((__force snd_ctl_elem_iface_t) 0)
-#define SNDRV_CTL_ELEM_IFACE_HWDEP ((__force snd_ctl_elem_iface_t) 1)
-#define SNDRV_CTL_ELEM_IFACE_MIXER ((__force snd_ctl_elem_iface_t) 2)
-#define SNDRV_CTL_ELEM_IFACE_PCM ((__force snd_ctl_elem_iface_t) 3)
-#define SNDRV_CTL_ELEM_IFACE_RAWMIDI ((__force snd_ctl_elem_iface_t) 4)
-#define SNDRV_CTL_ELEM_IFACE_TIMER ((__force snd_ctl_elem_iface_t) 5)
-#define SNDRV_CTL_ELEM_IFACE_SEQUENCER ((__force snd_ctl_elem_iface_t) 6)
+#define SNDRV_CTL_ELEM_IFACE_CARD (( snd_ctl_elem_iface_t) 0)
+#define SNDRV_CTL_ELEM_IFACE_HWDEP (( snd_ctl_elem_iface_t) 1)
+#define SNDRV_CTL_ELEM_IFACE_MIXER (( snd_ctl_elem_iface_t) 2)
+#define SNDRV_CTL_ELEM_IFACE_PCM (( snd_ctl_elem_iface_t) 3)
+#define SNDRV_CTL_ELEM_IFACE_RAWMIDI (( snd_ctl_elem_iface_t) 4)
+#define SNDRV_CTL_ELEM_IFACE_TIMER (( snd_ctl_elem_iface_t) 5)
+#define SNDRV_CTL_ELEM_IFACE_SEQUENCER (( snd_ctl_elem_iface_t) 6)
 #define SNDRV_CTL_ELEM_IFACE_LAST SNDRV_CTL_ELEM_IFACE_SEQUENCER
 #define SNDRV_CTL_ELEM_ACCESS_READ (1 << 0)
 #define SNDRV_CTL_ELEM_ACCESS_WRITE (1 << 1)
@@ -825,7 +813,7 @@ struct snd_ctl_elem_list {
   unsigned int space;
   unsigned int used;
   unsigned int count;
-  struct snd_ctl_elem_id __user * pids;
+  struct snd_ctl_elem_id  * pids;
   unsigned char reserved[50];
 };
 struct snd_ctl_elem_info {

--- a/kernel-headers/sound/audio_compressed_formats.h
+++ b/kernel-headers/sound/audio_compressed_formats.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __AUDIO_COMPRESSED_FORMATS_H
 #define __AUDIO_COMPRESSED_FORMATS_H
 #include <linux/types.h>

--- a/kernel-headers/sound/audio_effects.h
+++ b/kernel-headers/sound/audio_effects.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef _AUDIO_EFFECTS_H
 #define _AUDIO_EFFECTS_H
 #include <linux/types.h>
@@ -259,7 +247,7 @@ struct pbe_config_t {
   __s32 p1BandPassCoeffs[5 * 3];
   __s32 p1BassShelfCoeffs[5];
   __s32 p1TrebleShelfCoeffs[5];
-} __packed;
+} __attribute__((__packed__));
 struct pbe_params {
   __u32 device;
   __u32 enable_flag;

--- a/kernel-headers/sound/audio_slimslave.h
+++ b/kernel-headers/sound/audio_slimslave.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __AUDIO_SLIMSLAVE_H__
 #define __AUDIO_SLIMSLAVE_H__
 #include <linux/types.h>

--- a/kernel-headers/sound/compress_offload.h
+++ b/kernel-headers/sound/compress_offload.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __COMPRESS_OFFLOAD_H
 #define __COMPRESS_OFFLOAD_H
 #include <linux/types.h>

--- a/kernel-headers/sound/compress_params.h
+++ b/kernel-headers/sound/compress_params.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __SND_COMPRESS_PARAMS_H
 #define __SND_COMPRESS_PARAMS_H
 #include <linux/types.h>

--- a/kernel-headers/sound/devdep_params.h
+++ b/kernel-headers/sound/devdep_params.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef _DEV_DEP_H
 #define _DEV_DEP_H
 #include <linux/types.h>
@@ -25,7 +13,7 @@ struct dolby_param_data {
   __s32 be_id;
   __s32 param_id;
   __s32 length;
-  __s32 __user * data;
+  __s32  * data;
 };
 struct dolby_param_license {
   __s32 dmid;
@@ -59,7 +47,7 @@ struct dts_eagle_param_desc {
   __u32 size;
   __s32 offset;
   __u32 device;
-} __packed;
+} __attribute__((__packed__));
 #define HWDEP_FE_BASE 3000
 struct snd_pcm_mmap_fd {
   __s32 dir;

--- a/kernel-headers/sound/lsm_params.h
+++ b/kernel-headers/sound/lsm_params.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef _UAPI_LSM_PARAMS_H__
 #define _UAPI_LSM_PARAMS_H__
 #define LSM_POLLING_ENABLE_SUPPORT
@@ -90,7 +78,7 @@ struct snd_lsm_det_event_type {
   __u32 mode;
 };
 struct snd_lsm_sound_model_v2 {
-  __u8 __user * data;
+  __u8  * data;
   __u8 * confidence_level;
   __u32 data_size;
   enum lsm_detection_mode detection_mode;
@@ -135,21 +123,21 @@ struct lsm_params_info {
   __u32 module_id;
   __u32 param_id;
   __u32 param_size;
-  __u8 __user * param_data;
+  __u8  * param_data;
   __u32 param_type;
 };
 struct lsm_params_info_v2 {
   __u32 module_id;
   __u32 param_id;
   __u32 param_size;
-  __u8 __user * param_data;
+  __u8  * param_data;
   __u32 param_type;
   __u16 instance_id;
   __u16 stage_idx;
   __u32 model_id;
 };
 struct snd_lsm_module_params {
-  __u8 __user * params;
+  __u8  * params;
   __u32 num_params;
   __u32 data_size;
 };
@@ -163,7 +151,7 @@ struct snd_lsm_input_hw_params {
   __u32 sample_rate;
   __u16 bit_width;
   __u16 num_channels;
-} __packed;
+} __attribute__((__packed__));
 struct lsm_params_get_info {
   __u32 module_id;
   __u16 instance_id;
@@ -173,7 +161,7 @@ struct lsm_params_get_info {
   __u32 param_type;
   __u16 stage_idx;
   __u8 payload[0];
-} __packed;
+} __attribute__((__packed__));
 #define SNDRV_LSM_DEREG_SND_MODEL _IOW('U', 0x01, int)
 #define SNDRV_LSM_EVENT_STATUS _IOW('U', 0x02, struct snd_lsm_event_status)
 #define SNDRV_LSM_ABORT_EVENT _IOW('U', 0x03, int)

--- a/kernel-headers/sound/msmcal-hwdep.h
+++ b/kernel-headers/sound/msmcal-hwdep.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef _CALIB_HWDEP_H
 #define _CALIB_HWDEP_H
 #include <linux/types.h>
@@ -32,7 +20,7 @@ enum wcd_cal_type {
 };
 struct wcdcal_ioctl_buffer {
   __u32 size;
-  __u8 __user * buffer;
+  __u8  * buffer;
   enum wcd_cal_type cal_type;
 };
 #define SNDRV_CTL_IOCTL_HWDEP_CAL_TYPE _IOW('U', 0x1, struct wcdcal_ioctl_buffer)
@@ -43,7 +31,7 @@ enum q6afe_cal_type {
 };
 struct q6afecal_ioctl_buffer {
   __u32 size;
-  __u8 __user * buffer;
+  __u8  * buffer;
   enum q6afe_cal_type cal_type;
 };
 #define SNDRV_IOCTL_HWDEP_VAD_CAL_TYPE _IOW('U', 0x1, struct q6afecal_ioctl_buffer)

--- a/kernel-headers/sound/voice_params.h
+++ b/kernel-headers/sound/voice_params.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef __VOICE_PARAMS_H__
 #define __VOICE_PARAMS_H__
 #include <linux/types.h>

--- a/kernel-headers/sound/wcd-dsp-glink.h
+++ b/kernel-headers/sound/wcd-dsp-glink.h
@@ -1,21 +1,9 @@
-/****************************************************************************
- ****************************************************************************
- ***
- ***   This header was automatically generated from a Linux kernel header
- ***   of the same name, to make information necessary for userspace to
- ***   call into the kernel available to libc.  It contains only constants,
- ***   structures, and macros generated from the original header, and thus,
- ***   contains no copyrightable information.
- ***
- ***   To edit the content of this header, modify the corresponding
- ***   source file (e.g. under external/kernel-headers/original/) then
- ***   run bionic/libc/kernel/tools/update_all.py
- ***
- ***   Any manual change here will be lost the next time this script will
- ***   be run. You've been warned!
- ***
- ****************************************************************************
- ****************************************************************************/
+/*
+ * This file is auto-generated. Modifications will be lost.
+ *
+ * See https://android.googlesource.com/platform/bionic/+/master/libc/kernel/
+ * for more information.
+ */
 #ifndef _WCD_DSP_GLINK_H
 #define _WCD_DSP_GLINK_H
 #include <linux/types.h>


### PR DESCRIPTION
Patchset contains next changes:

- cp_headers: Identify lunch target by string
Any platform using the corresponding version of the Linux
kernel is suitable, as opposed to specifying a number,
which can point to a completely different target depending
on changes in the environment.

- cp_headers: Refactor for improved Reusability
Refactor the script to streamline repetitive header
processing logic by introducing a reusable function
process_headers. The following changes have been
implemented:
  - A new function process_headers has been added to
    encapsulate header processing logic. It takes three
    parameters:
      $1 (headers): A list of headers to process.
      $2 (prefix): The source path of the headers.
      $3 (suffix): The destination path of the headers.

  - Eliminated Redundancy:
      The repetitive blocks of code that handle different
      types of headers have been replaced with calls to
      process_headers.

  - Directory Creation:
      Ensures that the destination directory structure is
      created before copying headers.

  - No Change to Functionality:
      The script retains its original behavior but is now
      easier to read, maintain, and extend.

- cp_headers: Sync headers with the current kernel version

In sync with: https://github.com/sonyxperiadev/kernel-sony-msm-5.10-headers/pull/2